### PR TITLE
Zenodo changed their DOI badge paths... fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![DOI](https://zenodo.org/badge/75324979.svg)](https://zenodo.org/badge/latestdoi/75324979)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2550181.svg)](https://doi.org/10.5281/zenodo.2550181)
+
 
 # Effective Degrees of Freedom of the Pearson's Correlation Coefficient under Serial Correlation
 


### PR DESCRIPTION
The image link is fixed and works when I paste it into a browser... so it must be right... but when I view the README.md on Github it still shows up as a broken link... don't know.. but this is definately more "correct" than what we have now.